### PR TITLE
Errors on tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+- Show errors on new tab: Previously errors would print a message to the status bar and
+the traceback to the developer console, now message and traceback are printed to a new
+tab.
+
+## 0.1.0 (2022-05-04)
+
+- Initial release

--- a/REST-response.sublime-syntax
+++ b/REST-response.sublime-syntax
@@ -9,11 +9,6 @@ prototype:
 
 contexts:
   main:
-    - match: ^[^#]*(#.*)\s*$
-      name: http.comments
-      captures:
-        1: comment.line.sharp
-
     - match: ^\s*(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|CONNECT|TRACE)
       name: http.methods
       captures:
@@ -36,3 +31,8 @@ contexts:
       with_prototype:
         - match: ^[\}\]][\W]+$
           pop: true
+
+    - match: ^(REST Client:.*)$
+      name: http.error
+      captures:
+        1: invalid.illegal


### PR DESCRIPTION
Show errors on new tab: Previously errors would print a message to the status bar and
the traceback to the developer console, now message and traceback are printed to a new
tab.

Closes #1 