### PR TITLE
Encode payload in UTF-8

### DIFF
--- a/rest_client/client.py
+++ b/rest_client/client.py
@@ -1,7 +1,8 @@
-import certifi  # type: ignore
-import urllib3
 from dataclasses import dataclass
 from typing import Dict
+
+import certifi  # type: ignore
+import urllib3
 
 from .request import Request
 
@@ -16,9 +17,12 @@ class Response:
 
 
 def request(request: Request) -> Response:
-    print(f"Requesting {request.method} {request.url}")
+    print(f"Requesting {request.method} {request.url}: {request.body}")
     response = http.request(
-        request.method, request.url, headers=request.headers, body=request.body
+        request.method,
+        request.url,
+        headers=request.headers,
+        body=request.body.encode("utf-8") if request.body is not None else None,
     )
     return Response(
         status=response.status,

--- a/rest_client/request.py
+++ b/rest_client/request.py
@@ -1,4 +1,4 @@
-import typing as tp
+from typing import Optional, Mapping
 
 from dataclasses import dataclass
 
@@ -7,5 +7,5 @@ from dataclasses import dataclass
 class Request:
     url: str
     method: str = "GET"
-    headers: tp.Optional[tp.Mapping[str, str]] = None
-    body: tp.Optional[str] = None
+    headers: Optional[Mapping[str, str]] = None
+    body: Optional[str] = None

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,18 +1,24 @@
 import json
 
-from rest_client import Request, client
 from pytest_httpserver import HTTPServer
+
+from rest_client import Request, client
 
 
 def test_request(httpserver: HTTPServer) -> None:
     headers = {"Content-Type": "application/json"}
-    body = {"hello": "world"}
+    body = '{"hello": "world", "utf8": "is 🚀"}'
     response_body = {"hello": "back"}
-    httpserver.expect_request("/", headers=headers, json=body).respond_with_json(
+    httpserver.expect_request("/", headers=headers, data=body).respond_with_json(
         response_body
     )
 
-    req = Request(url=httpserver.url_for("/"), headers=headers, body=json.dumps(body))
+    req = Request(
+        method="POST",
+        url=httpserver.url_for("/"),
+        headers=headers,
+        body=body,
+    )
     response = client.request(req)
 
     assert response.status == 200


### PR DESCRIPTION
urllib3 will default to encoding payloads as latin-1,
when the payload has characters out of the range urllib3
will raise an error. Encode the payload as utf-8 as suggested.

Fixes #11 