### PR TITLE
Reuse the same view instead creating a new one on each request

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -55,6 +55,7 @@ class RestRequestCommand(sublime_plugin.WindowCommand):
     def __init__(self, *args: Tuple[Any], **kwargs: Dict[Any, Any]) -> None:
         super().__init__(*args, **kwargs)
         self._tick = 0
+        self._view = None
 
     def run(self, *args: Tuple[Any]) -> None:
         print("Running Sublime REST", args)
@@ -72,6 +73,12 @@ class RestRequestCommand(sublime_plugin.WindowCommand):
         thread = HttpRequestThread(request)
         thread.start()
         self.handle_thread(thread)
+
+    def get_view(self):
+        if not self._view or not self._view.is_valid():
+            self._view = self.window.new_file()
+
+        return self._view
 
     def handle_thread(self, thread: HttpRequestThread) -> None:
         if thread.is_alive():
@@ -92,7 +99,7 @@ class RestRequestCommand(sublime_plugin.WindowCommand):
             thread.request, response.status, response.headers, response.data
         )
 
-        response_view = self.window.new_file()
+        response_view = self.get_view()
         response_view.run_command("rest_replace_view_text", {"text": response_text})
         self.log_to_status(msg, response_view)
 
@@ -101,7 +108,7 @@ class RestRequestCommand(sublime_plugin.WindowCommand):
         self.log_to_status(msg)
         error = thread.get_error()
         error_text = self.get_error_content(thread.request, *error)
-        response_view = self.window.new_file()
+        response_view = self.get_view()
         response_view.run_command("rest_replace_view_text", {"text": error_text})
         self.log_to_status(msg, response_view)
 


### PR DESCRIPTION
Hi, today I've discovered this nice REST-CLIENT extension in vscode and after that
I just saw your nice ST4 plugin... really cool stuff. The only thing I was missing is each
time you make a new request you're creating new views over and over while the vscode's one is reusing the same one. That behaviour is really nice so you don't need
to switch context all the time.

Here's a little PR that allows to reuse the same view.

Another suggestion for another PR, maybe adding a setting that allows either replacing completely the view on each request (as you're already doing) or appending the new response. That way you could keep the history of all your responses in the same view.