### PR TITLE
allow disabling ssl validation

### DIFF
--- a/REST.sublime-settings
+++ b/REST.sublime-settings
@@ -7,5 +7,5 @@
     // in some rare cases it may be required to disable ssl certificate validation
     // note that this makes the plugin vulnerable to mitm attacks
     // so if not absolutely needed this setting should remain false
-    "disable_ssl_validation": true,
+    "disable_ssl_validation": false
 }

--- a/REST.sublime-settings
+++ b/REST.sublime-settings
@@ -4,4 +4,8 @@
     // Format JSON responses parameters, only relevant if `format_json` is true
     "format_json_indent": 2,
     "format_json_sort_keys": true,
+    // in some rare cases it may be required to disable ssl certificate validation
+    // note that this makes the plugin vulnerable to mitm attacks
+    // so if not absolutely needed this setting should remain false
+    "disable_ssl_validation": true,
 }

--- a/plugin.py
+++ b/plugin.py
@@ -16,9 +16,17 @@ import sublime_plugin
 from .rest_client import Response, client, parser
 from .rest_client.request import Request
 
+
 SETTINGS_FILE = "REST.sublime-settings"
 settings = sublime.load_settings(SETTINGS_FILE)
-client.setup(settings)
+
+
+def apply_settings(settings):
+    client.setup(settings)
+
+
+settings.add_on_change("tag", lambda: apply_settings(settings))
+apply_settings(settings)
 
 
 class RestException(Exception):

--- a/plugin.py
+++ b/plugin.py
@@ -17,6 +17,8 @@ from .rest_client import Response, client, parser
 from .rest_client.request import Request
 
 SETTINGS_FILE = "REST.sublime-settings"
+settings = sublime.load_settings(SETTINGS_FILE)
+client.setup(settings)
 
 
 class RestException(Exception):
@@ -58,7 +60,6 @@ class RestRequestCommand(sublime_plugin.WindowCommand):
     def __init__(self, *args: Tuple[Any], **kwargs: Dict[Any, Any]) -> None:
         super().__init__(*args, **kwargs)
         self._tick = 0
-        self.settings = sublime.load_settings(SETTINGS_FILE)
 
     def run(self, *args: Tuple[Any]) -> None:
         print("Running Sublime REST", args)
@@ -143,7 +144,7 @@ class RestRequestCommand(sublime_plugin.WindowCommand):
         http_status = HTTPStatus(status)
         content_type = headers.get("Content-Type")
         if (
-            self.settings["format_json"] is True
+            settings["format_json"] is True
             and content_type is not None
             and "application/json" in content_type
         ):
@@ -162,8 +163,8 @@ class RestRequestCommand(sublime_plugin.WindowCommand):
             payload = json.loads(body)
             return json.dumps(
                 payload,
-                indent=self.settings["format_json_indent"],
-                sort_keys=self.settings["format_json_indent"],
+                indent=settings["format_json_indent"],
+                sort_keys=settings["format_json_indent"],
             )
         except Exception:
             print("Failed to format JSON payload")

--- a/rest_client/client.py
+++ b/rest_client/client.py
@@ -6,7 +6,14 @@ import urllib3
 
 from .request import Request
 
-http = urllib3.PoolManager(cert_reqs="CERT_REQUIRED", ca_certs=certifi.where())
+http = None
+
+def setup(settings):
+    global http
+    http = urllib3.PoolManager(
+        cert_reqs="CERT_NONE" if settings.get("disable_ssl_validation") else "CERT_REQUIRED",
+        ca_certs=certifi.where()
+    )
 
 
 @dataclass


### PR DESCRIPTION
this adds an option to disable ssl cerrtificate validation.

we really need this in our case as we have some internal servers in an isolated vpn where we use self-signed certificates.

an alternative would be to allow additional certificates. but that is likely trickier and I would like to use this for now.

not sure if this is the right way. I could not find the settings in the settings menu, also not sure if sublime will actually apply this directly. didnt seem so. help welcome :)