### PR TITLE
Set request file syntax

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -89,6 +89,7 @@ class RestRequestCommand(sublime_plugin.WindowCommand):
                 )
             )
         else:
+            self.request_view.assign_syntax("scope:source.http")
             thread = HttpRequestThread(request)
             thread.start()
             self.handle_thread(thread)


### PR DESCRIPTION
Set the sintax of the request file to REST (request) when a request command is run and the request is succesfully parsed