### PR TITLE
Support showing output in a panel instead of a new file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Support for proxies.
+- New option for showing response view in a panel.
 
 ## 1.2.0 (2025-03-22)
 

--- a/REST.sublime-settings
+++ b/REST.sublime-settings
@@ -4,6 +4,8 @@
     // Format JSON responses parameters, only relevant if `format_json` is true
     "format_json_indent": 2,
     "format_json_sort_keys": true,
+    // Where the response should be shown, either `tab` or `panel`
+    "response_view": "tab",
     // Proxy URL, takes precendece over HTTP_PROXY and HTTPS_PROXY environment variables
     // "proxy_url": "http://localhost:3128",
 }

--- a/plugin.py
+++ b/plugin.py
@@ -18,6 +18,7 @@ from dotenv import dotenv_values
 from .rest_client import Response, client, parser
 from .rest_client.request import Request
 
+PANEL_NAME = "REST Client Response"
 SETTINGS_FILE = "REST.sublime-settings"
 
 
@@ -103,6 +104,15 @@ class RestRequestCommand(sublime_plugin.WindowCommand):
         else:
             self.on_error(thread)
 
+    def get_response_view(self) -> sublime.View:
+        response_view = self.settings.get("response_view")
+        if response_view == "panel":
+            view = self.window.create_output_panel(PANEL_NAME)
+            self.window.run_command("show_panel", {"panel": f"output.{PANEL_NAME}"})
+            return view
+        else:
+            return self.window.new_file()
+
     def on_success(self, thread: HttpRequestThread) -> None:
         msg = f"Response received in {thread.elapsed:.3f} seconds"
         self.log_to_status(msg)
@@ -111,7 +121,7 @@ class RestRequestCommand(sublime_plugin.WindowCommand):
             thread.request, response.status, response.headers, response.data
         )
 
-        response_view = self.window.new_file()
+        response_view = self.get_response_view()
         response_view.run_command("rest_replace_view_text", {"text": response_text})
         self.log_to_status(msg, response_view)
 
@@ -120,7 +130,7 @@ class RestRequestCommand(sublime_plugin.WindowCommand):
         self.log_to_status(msg)
         error = thread.get_error()
         error_text = self.get_error_content(thread.request, *error)
-        response_view = self.window.new_file()
+        response_view = self.get_response_view()
         response_view.run_command("rest_replace_view_text", {"text": error_text})
         self.log_to_status(msg, response_view)
 

--- a/tests/integration/test_rest_client.py
+++ b/tests/integration/test_rest_client.py
@@ -9,6 +9,8 @@ from unittesting import DeferrableTestCase
 from . import utils
 
 TIMEOUT = int(os.getenv("REST_CLIENT_TIMEOUT", 500))
+PANEL_NAME = "REST Client Response"
+SETTINGS_FILE = "REST.sublime-settings"
 
 
 class TestRestClient(DeferrableTestCase):
@@ -16,13 +18,20 @@ class TestRestClient(DeferrableTestCase):
         self.window = sublime.active_window()
         self.view = self.window.new_file()
         self.response_view = None
-        settings = sublime.load_settings("Preferences.sublime-settings")
-        settings.set("close_windows_when_empty", False)
+        self.plugin_settings = sublime.load_settings(SETTINGS_FILE)
+        editor_settings = sublime.load_settings("Preferences.sublime-settings")
+        editor_settings.set("close_windows_when_empty", False)
 
     def tearDown(self) -> None:
+        # Make sure the UnitTesting panel is showing after the test run
+        self.window.run_command("show_panel", {"panel": "output.UnitTesting"})
+
         if self.response_view:
-            self.response_view.window().focus_view(self.response_view)
-            self.response_view.window().run_command("close_file")
+            if self.plugin_settings.get("response_view") == "panel":
+                self.window.destroy_output_panel(PANEL_NAME)
+            else:
+                self.response_view.window().focus_view(self.response_view)
+                self.response_view.window().run_command("close_file")
 
         if self.view:
             self.view.set_scratch(True)
@@ -30,7 +39,12 @@ class TestRestClient(DeferrableTestCase):
             self.view.window().run_command("close_file")
 
     def _get_response_view_contents(self) -> str:
-        self.response_view = self.window.active_view()
+        if self.plugin_settings.get("response_view") == "panel":
+            self.response_view = self.window.find_output_panel(PANEL_NAME)
+        else:
+            self.response_view = self.window.active_view()
+
+        self.assertIsNotNone(self.response_view, "REST response view not available")
         return utils.get_contents_of_view(self.response_view)
 
     def _get_response(
@@ -49,6 +63,7 @@ class TestRestClient(DeferrableTestCase):
         return status, headers, cast(str, body)
 
     def test_simple_get(self) -> Iterator[int]:
+        self.plugin_settings.set("response_view", "tab")
         utils.set_text_on_view(self.view, "https://httpbin.org/get")
         self.window.run_command("rest_request")
         yield TIMEOUT
@@ -58,6 +73,7 @@ class TestRestClient(DeferrableTestCase):
         self.assertIn("url", body)
 
     def test_get_with_variable(self) -> Iterator[int]:
+        self.plugin_settings.set("response_view", "panel")
         text = "\n".join(
             [
                 "@token = ABC123",


### PR DESCRIPTION
### Description

Adds a new setting `response_view` that allows the user to choose between opening up the response in a new `file` view (default) or in a `panel` view. Currently, the output panel is reused for requests so previous responses are overwritten and lost, but the last result can be re-opened using the panel switcher.

Also updated the integration tests so they run correctly in either mode. I updated one test to explicitly set the mode to `file` and another to set the mode to `panel`.

### Screenshot

<img width="1075" height="1078" alt="Screenshot 2025-10-19 at 11 08 47 PM" src="https://github.com/user-attachments/assets/41130e2d-c4aa-49bc-8d88-df338c4db598" />
