### PR TITLE
Proxy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Support for proxies.
+
 ## 1.2.0 (2025-03-22)
 
 - Upgrade urllib3 to 2.2.3.

--- a/README.md
+++ b/README.md
@@ -224,6 +224,14 @@ GET https://httpbin.org/get
 Authorization: Bearer {{$dotenv TOKEN}}
 ```
 
+#### Proxy support
+
+Sublime REST Client will respect the `HTTP_PROXY` and `HTTPS_PROXY` environment variables.
+Alternatively, you can set a `proxy_url` setting which will take precendence over the
+environment variables.
+
+SOCKS proxies are not supported yet, only HTTP and HTTPS.
+
 ## Development
 
 1. Install the [`just`](https://github.com/casey/just) command runner

--- a/REST.sublime-settings
+++ b/REST.sublime-settings
@@ -4,4 +4,6 @@
     // Format JSON responses parameters, only relevant if `format_json` is true
     "format_json_indent": 2,
     "format_json_sort_keys": true,
+    // Proxy URL, takes precendece over HTTP_PROXY and HTTPS_PROXY environment variables
+    // "proxy_url": "http://localhost:3128",
 }

--- a/plugin.py
+++ b/plugin.py
@@ -65,11 +65,10 @@ class RestRequestCommand(sublime_plugin.WindowCommand):
         self.settings.add_on_change(
             "rest_client", lambda: client.manager.configure(self.settings)
         )
-
-    def run(self, *args: Tuple[Any]) -> None:
-        print("Running Sublime REST", args)
         self.request_view = self.window.active_view()
 
+    def run(self, *args: Tuple[Any]) -> None:
+        self.request_view = self.window.active_view()
         contents, pos = self.get_request_text_from_selection()
         if contents == "":
             self.log_to_status("Invalid request text: `{}`".format(contents))
@@ -82,14 +81,10 @@ class RestRequestCommand(sublime_plugin.WindowCommand):
             request = parser.parse(contents, pos, dotenv_vars)
         except Exception:
             self.log_to_status(
-                " ".join(
-                    [
-                        "Error while parsing REST request.",
-                        "Please check the console (View > Show Console)",
-                        "and report the error on",
-                        "https://github.com/yeraydiazdiaz/sublime-rest-client/issues",
-                    ]
-                )
+                "Error while parsing REST request. "
+                "Please check the console (View > Show Console) "
+                "and report the error on "
+                "https://github.com/yeraydiazdiaz/sublime-rest-client/issues"
             )
         else:
             self.request_view.assign_syntax("scope:source.http")

--- a/rest_client/client.py
+++ b/rest_client/client.py
@@ -57,7 +57,7 @@ class Response:
 
 
 def request(request: Request) -> Response:
-    print(f"Requesting {request.method} {request.url}: {request.body}")
+    print(f"Requesting {request.method} {request.url}")
     pool = manager.get_pool(request.host)
     response = pool.request(
         request.method,

--- a/rest_client/client.py
+++ b/rest_client/client.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Union
 
@@ -8,13 +9,8 @@ from .request import Request
 
 
 class Manager:
-    _default_pool: Optional[urllib3.PoolManager] = None
+    _default_pool: Optional[Union[urllib3.PoolManager, urllib3.ProxyManager]] = None
     pools_per_host: Dict[str, urllib3.HTTPSConnectionPool] = {}
-
-    def __init__(self) -> None:
-        self._default_pool = urllib3.PoolManager(
-            cert_reqs="CERT_REQUIRED", ca_certs=certifi.where()
-        )
 
     @property
     def default_pool(self) -> urllib3.PoolManager:
@@ -24,6 +20,16 @@ class Manager:
         return self._default_pool
 
     def configure(self, settings: Dict[str, Any]) -> None:
+        proxy_url = self._get_http_proxy_url(settings)
+        if proxy_url:
+            print(f"Configuring client with proxy URL {proxy_url}")
+            self._default_pool = urllib3.ProxyManager(
+                proxy_url=proxy_url, cert_reqs="CERT_REQUIRED", ca_certs=certifi.where()
+            )
+        else:
+            self._default_pool = urllib3.PoolManager(
+                cert_reqs="CERT_REQUIRED", ca_certs=certifi.where()
+            )
         for host_with_port, host_settings in settings.get("host_settings", {}).items():
             kwargs = self._settings_to_kw(host_settings)
             host = host_with_port
@@ -47,6 +53,10 @@ class Manager:
             if setting == "disable_ssl_validation" and value:
                 kwargs["cert_reqs"] = "CERT_NONE"
         return kwargs
+
+    def _get_http_proxy_url(self, settings: Dict[str, Any]) -> Optional[str]:
+        proxy_url = settings.get("proxy_url")
+        return proxy_url or os.environ.get("HTTPS_PROXY", os.environ.get("HTTP_PROXY"))
 
 
 @dataclass

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,6 +1,9 @@
 import json
+import os
 
+import pytest
 from pytest_httpserver import HTTPServer
+import urllib3
 
 from rest_client import Request, client
 
@@ -19,6 +22,7 @@ def test_request(httpserver: HTTPServer) -> None:
         headers=headers,
         body=body,
     )
+    client.manager.configure({})
     response = client.request(req)
 
     assert response.status == 200
@@ -28,6 +32,20 @@ def test_request(httpserver: HTTPServer) -> None:
 def test_manager_configure_with_no_hosts() -> None:
     client.manager.configure({})
     assert client.manager.pools_per_host == {}
+
+
+@pytest.mark.parametrize("env_var_or_setting", ("ENV_VAR", "SETTING", None))
+def test_manager_configure_with_proxy(env_var_or_setting: str) -> None:
+    if env_var_or_setting == "ENV_VAR":
+        os.environ["HTTP_PROXY"] = "http://localhost:3128"
+        client.manager.configure({})
+        assert isinstance(client.manager.default_pool, urllib3.ProxyManager)
+    elif env_var_or_setting == "SETTING":
+        client.manager.configure({"proxy_url": "http://localhost:3128"})
+        assert isinstance(client.manager.default_pool, urllib3.ProxyManager)
+    else:
+        client.manager.configure({"proxy_url": "http://localhost:3128"})
+        assert isinstance(client.manager.default_pool, urllib3.PoolManager)
 
 
 def test_manager_configure_creates_connection_pools() -> None:


### PR DESCRIPTION
Sublime REST Client will respect the `HTTP_PROXY` and `HTTPS_PROXY` environment variables.
Alternatively, you can set a `proxy_url` setting which will take precendence over the
environment variables.

SOCKS proxies are not supported yet, only HTTP and HTTPS.

Closes #38 