### PR TITLE
Improve stability of integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@
 name: CI
 
 on: [push, pull_request]
+env:
+  REST_CLIENT_TIMEOUT: 3000
 
 jobs:
   lint:

--- a/plugin.py
+++ b/plugin.py
@@ -18,7 +18,7 @@ from dotenv import dotenv_values
 from .rest_client import Response, client, parser
 from .rest_client.request import Request
 
-PANEL_NAME = "REST Client Response"
+OUTPUT_NAME = "REST Client Response"
 SETTINGS_FILE = "REST.sublime-settings"
 
 
@@ -107,11 +107,12 @@ class RestRequestCommand(sublime_plugin.WindowCommand):
     def get_response_view(self) -> sublime.View:
         response_view = self.settings.get("response_view")
         if response_view == "panel":
-            view = self.window.create_output_panel(PANEL_NAME)
-            self.window.run_command("show_panel", {"panel": f"output.{PANEL_NAME}"})
-            return view
+            view = self.window.create_output_panel(OUTPUT_NAME)
+            self.window.run_command("show_panel", {"panel": f"output.{OUTPUT_NAME}"})
         else:
-            return self.window.new_file()
+            view = self.window.new_file()
+            view.set_name(OUTPUT_NAME)
+        return view
 
     def on_success(self, thread: HttpRequestThread) -> None:
         msg = f"Response received in {thread.elapsed:.3f} seconds"

--- a/tests/integration/test_rest_client.py
+++ b/tests/integration/test_rest_client.py
@@ -2,13 +2,14 @@ import os
 import sys
 import unittest
 from typing import Dict, Iterator, Tuple, Union, cast
+from time import sleep
 
 import sublime
 from unittesting import DeferrableTestCase
 
 from . import utils
 
-TIMEOUT = int(os.getenv("REST_CLIENT_TIMEOUT", 500))
+TIMEOUT = int(os.getenv("REST_CLIENT_TIMEOUT", 1000))
 PANEL_NAME = "REST Client Response"
 SETTINGS_FILE = "REST.sublime-settings"
 
@@ -38,11 +39,22 @@ class TestRestClient(DeferrableTestCase):
             self.view.window().focus_view(self.view)
             self.view.window().run_command("close_file")
 
+    def _get_response_view(self) -> sublime.View:
+        count = 0
+        while self.response_view is None and count <= 10:
+            for view in self.window.views():
+                if view.name() == PANEL_NAME:
+                    self.response_view = view
+                    return self.response_view
+            count += 1
+            sleep(0.1)
+        raise RuntimeError("Unable to find response view")
+
     def _get_response_view_contents(self) -> str:
         if self.plugin_settings.get("response_view") == "panel":
             self.response_view = self.window.find_output_panel(PANEL_NAME)
         else:
-            self.response_view = self.window.active_view()
+            self.response_view = self._get_response_view()
 
         self.assertIsNotNone(self.response_view, "REST response view not available")
         return utils.get_contents_of_view(self.response_view)

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -19,11 +19,15 @@ def get_contents_of_view(view: sublime.View) -> str:
 def parse_response(
     response_text: str, parse_json: bool = True
 ) -> Tuple[str, Dict, Union[Dict, str]]:
-    status, headers, body = response_text.split("\n\n")
-    headers_dict = {}
-    for header in headers.split("\n"):
-        k, v = header.split(": ")
-        headers_dict[k] = v
+    try:
+        status, headers, body = response_text.split("\n\n")
+    except ValueError:
+        raise ValueError(f"Unable to split response text: {response_text}")
+    else:
+        headers_dict = {}
+        for header in headers.split("\n"):
+            k, v = header.split(": ")
+            headers_dict[k] = v
 
-    body = json.loads(body) if parse_json else body
-    return status, headers_dict, body
+        body = json.loads(body) if parse_json else body
+        return status, headers_dict, body


### PR DESCRIPTION
To help debug the most common issue on integration tests, a ValueError splitting the response text on new lines.