### PR TITLE
Add edit_settings to commands

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -2,5 +2,13 @@
     {
         "caption": "REST: Send request",
         "command": "rest_request"
+    },
+    {
+        "caption": "Preferences: REST Client Settings",
+        "command": "edit_settings",
+        "args": {
+            "base_file": "${packages}/REST Client/REST.sublime-settings",
+            "default": "{\n\t$0\n}\n"
+        }
     }
 ]


### PR DESCRIPTION
I'm new to Sublime Text, so I don't know how to open package settings without using Command Palette.
Adding `edit_settings` to `Default.sublime-commands` would simplify this process, as many packages already use this approach