### PR TITLE
Fix incorrect splitting of body

### DIFF
--- a/rest_client/parser.py
+++ b/rest_client/parser.py
@@ -74,9 +74,11 @@ def _get_request_block(contents: str, pos: int) -> str:
 
 
 def _parse_request_block(block: str) -> Request:
-    [url_section, *body_section] = block.split("\n\n", 2)
+    [url_section, *body_section] = block.split("\n\n", maxsplit=1)
     method, url, headers = _parse_url_section(url_section)
-    body = body_section[0] if body_section else None
+    body = None
+    if body_section:
+        body = body_section[0].strip() or None
     return Request(url=url, method=method, headers=headers, body=body)
 
 

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -194,3 +194,28 @@ def test_variable_substitution_dotenv(sep: str) -> None:
         headers={"authentication": "bearer 1234", "content-type": "application/json"},
         body='{"dotenv": 1, "local": 2}',
     )
+
+
+@pytest.mark.parametrize("sep", ("\n", "\r\n"))
+def test_body_must_be_treated_as_rest_of_block(sep: str) -> None:
+    contents = sep.join(
+        [
+            "POST https://example.org",
+            "content-type: application/json",
+            "",
+            "",
+            '{ "foo": "bar",',
+            "",
+            "",
+            '"fizz": "buzz" }',
+        ]
+    )
+
+    req = parser.parse(contents, 0)
+
+    assert req == Request(
+        url="https://example.org",
+        method="POST",
+        headers={"content-type": "application/json"},
+        body="\n".join(['{ "foo": "bar",', "", "", '"fizz": "buzz" }']),
+    )


### PR DESCRIPTION
The current implementation does not allow blank lines in the request body: the parser ignores everything after the first blank line. However, blank lines are valid in an HTTP body. This PR fixes the parsing logic so that all content after the request headers and the blank line is treated as the request body