### PR TITLE
Improve response highlighting

### DIFF
--- a/REST-response.sublime-syntax
+++ b/REST-response.sublime-syntax
@@ -14,7 +14,7 @@ contexts:
       captures:
         1: keyword.control.http
 
-    - match: (\d{3} [A-Z ]+)
+    - match: (\d{3} [A-Za-z_ ]+)
       name: http.status_code
       captures:
         1: string.other.http


### PR DESCRIPTION
Extend syntax highlighting to cover reason phrases like `BAD_REQUEST` or `Bad Request`